### PR TITLE
Add Snyk vulnerability badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # MVVMacro
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/altiplane-software/MVVMacro/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/altiplane-software/MVVMacro/tree/main)
+[![Known Vulnerabilities](https://snyk.io/test/github/altiplane-software/MVVMacro/badge.svg)](https://snyk.io/test/github/altiplane-software/MVVMacro)
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Add Snyk vulnerability badge to README.md alongside the existing CircleCI badge
- Helps users quickly see the security status of the project

## Test plan
- Verify badge appears correctly in README
- Verify badge links to the correct Snyk project URL