### PR TITLE
Add caching to CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,15 +8,30 @@ jobs:
       FASTLANE_SKIP_UPDATE_CHECK: true
     steps:
       - checkout
+      
+      # Restore Swift package cache
+      - restore_cache:
+          keys:
+            - spm-cache-v1-{{ checksum "Package.resolved" }}
+            - spm-cache-v1-
+      
       - run:
           name: Setup development environment
           command: |
             chmod +x setup.sh
             ./setup.sh
+      
       - run:
           name: Build and test
           command: |
             make test
+      
+      # Save Swift package cache
+      - save_cache:
+          key: spm-cache-v1-{{ checksum "Package.resolved" }}
+          paths:
+            - ~/.swiftpm
+            - .build
 
 workflows:
   version: 2


### PR DESCRIPTION
## Summary
- Implements caching for Swift Package Manager dependencies in CircleCI
- Caches the ~/.swiftpm directory and .build directory between builds
- Uses Package.resolved as cache key to ensure proper cache invalidation

## Benefits
- Significantly faster CI builds by avoiding redundant package downloads
- Reduces network usage and external dependencies during builds
- Speeds up feedback cycle for developers

## Implementation Details
- Added restore_cache step before the build to load cached dependencies
- Added save_cache step after successful builds to update the cache
- Used checksum of Package.resolved as the primary cache key
- Included fallback cache key for partial cache hits

## Test plan
- Verify build completes successfully with caching enabled
- Confirm subsequent builds show cache restoration messages in CI logs
- Validate that build times decrease for builds after initial cache creation